### PR TITLE
uapi: add metadata flag to xdp flags

### DIFF
--- a/include/uapi/linux/if_link.h
+++ b/include/uapi/linux/if_link.h
@@ -1172,11 +1172,13 @@ enum {
 #define XDP_FLAGS_DRV_MODE		(1U << 2)
 #define XDP_FLAGS_HW_MODE		(1U << 3)
 #define XDP_FLAGS_REPLACE		(1U << 4)
+#define XDP_FLAGS_USE_METADATA		(1U << 5)
 #define XDP_FLAGS_MODES			(XDP_FLAGS_SKB_MODE | \
 					 XDP_FLAGS_DRV_MODE | \
 					 XDP_FLAGS_HW_MODE)
 #define XDP_FLAGS_MASK			(XDP_FLAGS_UPDATE_IF_NOEXIST | \
-					 XDP_FLAGS_MODES | XDP_FLAGS_REPLACE)
+					 XDP_FLAGS_MODES | XDP_FLAGS_REPLACE | \
+					 XDP_FLAGS_USE_METADATA)
 
 /* These are stored into IFLA_XDP_ATTACHED on dump. */
 enum {


### PR DESCRIPTION
Add this flag to allow user to inform driver that metadata is used.
Set flag is sent to driver via exsisting ndo_bpf call in flag field.

Signed-off-by: Michal Swiatkowski <michal.swiatkowski@intel.com>