### PR TITLE
ice: use xdp generic metadata

### DIFF
--- a/drivers/net/ethernet/intel/ice/ice.h
+++ b/drivers/net/ethernet/intel/ice/ice.h
@@ -348,6 +348,8 @@ struct ice_vsi {
 	u16 num_xdp_txq;		 /* Used XDP queues */
 	u8 xdp_mapping_mode;		 /* ICE_MAP_MODE_[CONTIG|SCATTER] */
 
+	bool xdp_metadata_support;	 /* true if VSI should support xdp meta */
+
 	/* setup back reference, to which aggregator node this VSI
 	 * corresponds to
 	 */

--- a/drivers/net/ethernet/intel/ice/ice_txrx.c
+++ b/drivers/net/ethernet/intel/ice/ice_txrx.c
@@ -1135,6 +1135,9 @@ int ice_clean_rx_irq(struct ice_ring *rx_ring, int budget)
 		hard_start = page_address(rx_buf->page) + rx_buf->page_offset -
 			     offset;
 		xdp_prepare_buff(&xdp, hard_start, offset, size, true);
+
+		if (likely(rx_ring->xdp_metadata_support))
+			ice_xdp_set_meta(&xdp, rx_desc);
 #if (PAGE_SIZE > 4096)
 		/* At larger PAGE_SIZE, frame_sz depend on len size */
 		xdp.frame_sz = ice_rx_frame_truesize(rx_ring, size);

--- a/drivers/net/ethernet/intel/ice/ice_txrx.h
+++ b/drivers/net/ethernet/intel/ice/ice_txrx.h
@@ -276,6 +276,7 @@ struct ice_ring {
 	u16 q_handle;			/* Queue handle per TC */
 
 	u8 ring_active:1;		/* is ring online or not */
+	u8 xdp_metadata_support:1;	/* is xdp metadata support */
 
 	u16 count;			/* Number of descriptors */
 	u16 reg_idx;			/* HW register index of the ring */
@@ -301,6 +302,8 @@ struct ice_ring {
 	/* CL3 - 3rd cacheline starts here */
 	struct xdp_rxq_info xdp_rxq;
 	struct sk_buff *skb;
+
+
 	/* CLX - the below items are only accessed infrequently and should be
 	 * in their own cache line if possible
 	 */

--- a/drivers/net/ethernet/intel/ice/ice_txrx_lib.h
+++ b/drivers/net/ethernet/intel/ice/ice_txrx_lib.h
@@ -46,6 +46,16 @@ static inline void ice_xdp_ring_update_tail(struct ice_ring *xdp_ring)
 	writel_relaxed(xdp_ring->next_to_use, xdp_ring->tail);
 }
 
+static inline void ice_xdp_set_meta(struct xdp_buff *xdp, union ice_32b_rx_flex_desc *desc)
+{
+	struct ice_32b_rx_flex_desc_nic *flex = (struct ice_32b_rx_flex_desc_nic *)desc;
+	struct xdp_meta_generic *md = xdp->data - sizeof(struct xdp_meta_generic);
+
+	xdp->data_meta = md;
+	md->rxcvid = le16_to_cpu(flex->flex_ts.flex.vlan_id);
+	md->hash = le32_to_cpu(flex->rss_hash);
+}
+
 void ice_finalize_xdp_rx(struct ice_ring *rx_ring, unsigned int xdp_res);
 int ice_xmit_xdp_buff(struct xdp_buff *xdp, struct ice_ring *xdp_ring);
 int ice_xmit_xdp_ring(void *data, u16 size, struct ice_ring *xdp_ring);


### PR DESCRIPTION
As starting point add vlan id and rss hash if xdp metadata is supported.

Add xd_metadata_support field in VSI to allow easy passing this value to
ring configuration.

Signed-off-by: Michal Swiatkowski <michal.swiatkowski@intel.com>