### PR TITLE
[Draft] Patching in BTF ID + unifying vmlinux and module BTFs acquisition

### DIFF
--- a/drivers/net/ethernet/intel/ice/ice.h
+++ b/drivers/net/ethernet/intel/ice/ice.h
@@ -38,6 +38,7 @@
 #include <linux/avf/virtchnl.h>
 #include <linux/cpu_rmap.h>
 #include <linux/dim.h>
+#include <linux/btf.h>
 #include <net/devlink.h>
 #include <net/ipv6.h>
 #include <net/xdp_sock.h>
@@ -350,6 +351,7 @@ struct ice_vsi {
 	u8 xdp_mapping_mode;		 /* ICE_MAP_MODE_[CONTIG|SCATTER] */
 
 	bool xdp_metadata_support;	 /* true if VSI should support xdp meta */
+	s32 btf_id;
 
 	/* setup back reference, to which aggregator node this VSI
 	 * corresponds to

--- a/drivers/net/ethernet/intel/ice/ice.h
+++ b/drivers/net/ethernet/intel/ice/ice.h
@@ -349,6 +349,8 @@ struct ice_vsi {
 	u16 num_xdp_txq;		 /* Used XDP queues */
 	u8 xdp_mapping_mode;		 /* ICE_MAP_MODE_[CONTIG|SCATTER] */
 
+	bool xdp_metadata_support;	 /* true if VSI should support xdp meta */
+
 	/* setup back reference, to which aggregator node this VSI
 	 * corresponds to
 	 */

--- a/drivers/net/ethernet/intel/ice/ice_main.c
+++ b/drivers/net/ethernet/intel/ice/ice_main.c
@@ -2423,11 +2423,15 @@ static void ice_xdp_rings_set_metadata(struct ice_vsi *vsi)
 {
 	int i;
 
-	ice_for_each_rxq(vsi, i)
+	ice_for_each_rxq(vsi, i) {
 		vsi->rx_rings[i]->xdp_metadata_support = vsi->xdp_metadata_support;
+		vsi->rx_rings[i]->btf_id = vsi->btf_id;
+	}
 
-	for (i = 0; i < vsi->num_xdp_txq; i++)
+	for (i = 0; i < vsi->num_xdp_txq; i++) {
 		vsi->xdp_rings[i]->xdp_metadata_support = vsi->xdp_metadata_support;
+		vsi->xdp_rings[i]->btf_id = vsi->btf_id;
+	}
 }
 
 /**
@@ -2646,8 +2650,10 @@ ice_xdp_setup_prog(struct ice_vsi *vsi, struct bpf_prog *prog,
 		}
 	}
 
-	if (flags & XDP_FLAGS_USE_METADATA)
+	if (flags & XDP_FLAGS_USE_METADATA) {
 		vsi->xdp_metadata_support = true;
+		vsi->btf_id = btf_get_type_id(THIS_MODULE, "xdp_meta_generic", BTF_KIND_STRUCT);
+	}	
 
 	if (!ice_is_xdp_ena_vsi(vsi) && prog) {
 		vsi->num_xdp_txq = vsi->alloc_rxq;

--- a/drivers/net/ethernet/intel/ice/ice_txrx.c
+++ b/drivers/net/ethernet/intel/ice/ice_txrx.c
@@ -1137,7 +1137,8 @@ int ice_clean_rx_irq(struct ice_ring *rx_ring, int budget)
 		xdp_prepare_buff(&xdp, hard_start, offset, size, true);
 
 		if (likely(rx_ring->xdp_metadata_support))
-			ice_xdp_set_meta(&xdp, rx_desc);
+			ice_xdp_set_meta(&xdp, rx_desc, rx_ring->btf_id);
+
 #if (PAGE_SIZE > 4096)
 		/* At larger PAGE_SIZE, frame_sz depend on len size */
 		xdp.frame_sz = ice_rx_frame_truesize(rx_ring, size);

--- a/drivers/net/ethernet/intel/ice/ice_txrx.c
+++ b/drivers/net/ethernet/intel/ice/ice_txrx.c
@@ -1135,6 +1135,9 @@ int ice_clean_rx_irq(struct ice_ring *rx_ring, int budget)
 		hard_start = page_address(rx_buf->page) + rx_buf->page_offset -
 			     offset;
 		xdp_prepare_buff(&xdp, hard_start, offset, size, true);
+
+		if (likely(rx_ring->xdp_metadata_support))
+			ice_xdp_set_meta(&xdp, rx_desc);
 #if (PAGE_SIZE > 4096)
 		/* At larger PAGE_SIZE, frame_sz depend on len size */
 		xdp.frame_sz = ice_rx_frame_truesize(rx_ring, size);

--- a/drivers/net/ethernet/intel/ice/ice_txrx.h
+++ b/drivers/net/ethernet/intel/ice/ice_txrx.h
@@ -302,6 +302,7 @@ struct ice_ring {
 	/* CL3 - 3rd cacheline starts here */
 	struct xdp_rxq_info xdp_rxq;
 	struct sk_buff *skb;
+	s32 btf_id;
 
 
 	/* CLX - the below items are only accessed infrequently and should be

--- a/drivers/net/ethernet/intel/ice/ice_txrx.h
+++ b/drivers/net/ethernet/intel/ice/ice_txrx.h
@@ -276,6 +276,7 @@ struct ice_ring {
 	u16 q_handle;			/* Queue handle per TC */
 
 	u8 ring_active:1;		/* is ring online or not */
+	u8 xdp_metadata_support:1;	/* is xdp metadata support */
 
 	u16 count;			/* Number of descriptors */
 	u16 reg_idx;			/* HW register index of the ring */
@@ -301,6 +302,8 @@ struct ice_ring {
 	/* CL3 - 3rd cacheline starts here */
 	struct xdp_rxq_info xdp_rxq;
 	struct sk_buff *skb;
+
+
 	/* CLX - the below items are only accessed infrequently and should be
 	 * in their own cache line if possible
 	 */

--- a/drivers/net/ethernet/intel/ice/ice_txrx_lib.h
+++ b/drivers/net/ethernet/intel/ice/ice_txrx_lib.h
@@ -46,14 +46,24 @@ static inline void ice_xdp_ring_update_tail(struct ice_ring *xdp_ring)
 	writel_relaxed(xdp_ring->next_to_use, xdp_ring->tail);
 }
 
-static inline void ice_xdp_set_meta(struct xdp_buff *xdp, union ice_32b_rx_flex_desc *desc)
+static inline void ice_xdp_set_meta(struct xdp_buff *xdp, union ice_32b_rx_flex_desc *desc, s32 btf_id)
 {
 	struct ice_32b_rx_flex_desc_nic *flex = (struct ice_32b_rx_flex_desc_nic *)desc;
 	struct xdp_meta_generic *md = xdp->data - sizeof(struct xdp_meta_generic);
 
-	xdp->data_meta = md;
 	md->rxcvid = le16_to_cpu(flex->flex_ts.flex.vlan_id);
 	md->hash = le32_to_cpu(flex->rss_hash);
+
+	md->flags = 0;
+	md->free_slot = 0;
+	md->csum_off = 0;
+	md->txcvid = 0;
+	md->csum = 0;
+	md->tstamp = 0;
+
+	md->btf_id = btf_id;
+
+	xdp->data_meta = md;
 }
 
 void ice_finalize_xdp_rx(struct ice_ring *rx_ring, unsigned int xdp_res);

--- a/drivers/net/ethernet/intel/ice/ice_txrx_lib.h
+++ b/drivers/net/ethernet/intel/ice/ice_txrx_lib.h
@@ -46,6 +46,16 @@ static inline void ice_xdp_ring_update_tail(struct ice_ring *xdp_ring)
 	writel_relaxed(xdp_ring->next_to_use, xdp_ring->tail);
 }
 
+static inline void ice_xdp_set_meta(struct xdp_buff *xdp, union ice_32b_rx_flex_desc *desc)
+{
+	struct ice_32b_rx_flex_desc_nic *flex = (struct ice_32b_rx_flex_desc_nic *)desc;
+	struct xdp_meta_generic *md = xdp->data - sizeof(struct xdp_meta_generic);
+
+	xdp->data_meta = md;
+	md->rxcvid = le16_to_cpu(flex->flex_ts.flex.vlan_id);
+	md->hash = le32_to_cpu(flex->rss_hash);
+}
+
 void ice_finalize_xdp_rx(struct ice_ring *rx_ring, unsigned int xdp_res);
 int ice_xmit_xdp_buff(struct xdp_buff *xdp, struct ice_ring *xdp_ring);
 int ice_xmit_xdp_ring(void *data, u16 size, struct ice_ring *xdp_ring);

--- a/include/linux/btf.h
+++ b/include/linux/btf.h
@@ -94,6 +94,7 @@ u32 btf_obj_id(const struct btf *btf);
 bool btf_is_kernel(const struct btf *btf);
 bool btf_is_module(const struct btf *btf);
 struct module *btf_try_get_module(const struct btf *btf);
+s32 btf_get_type_id(const struct module *mod, char *name, u32 kind);
 u32 btf_nr_types(const struct btf *btf);
 bool btf_member_is_reg_int(const struct btf *btf, const struct btf_type *s,
 			   const struct btf_member *m,

--- a/include/net/xdp.h
+++ b/include/net/xdp.h
@@ -76,6 +76,24 @@ struct xdp_buff {
 	u32 frame_sz; /* frame size to deduce data_hard_end/reserved tailroom*/
 };
 
+struct xdp_meta_generic {
+	// Tx part
+	u32        flags;
+	u16        free_slot;
+	u16        csum_off;
+	u16        txcvid;
+
+	// Rx part
+	u16        rxcvid;
+	u32        csum;
+	u32        hash;
+	u64        tstamp;
+
+	// BTF ID
+	u32        btf_id;
+} __packed __aligned(8);
+static_assert(sizeof(struct xdp_meta_generic) == 32);
+
 static __always_inline void
 xdp_init_buff(struct xdp_buff *xdp, u32 frame_sz, struct xdp_rxq_info *rxq)
 {

--- a/include/uapi/linux/bpf.h
+++ b/include/uapi/linux/bpf.h
@@ -873,6 +873,7 @@ enum bpf_cmd {
 	BPF_ITER_CREATE,
 	BPF_LINK_DETACH,
 	BPF_PROG_BIND_MAP,
+	BPF_BTF_VMLINUX_INFO,
 };
 
 enum bpf_map_type {
@@ -1395,6 +1396,11 @@ union bpf_attr {
 		__u32		info_len;
 		__aligned_u64	info;
 	} info;
+
+	struct { /* anonymous struct used by BPF_BTF_VMLINUX_INFO */
+		__u32 info_len;
+		__aligned_u64 info;
+	} info_vmlinux;
 
 	struct { /* anonymous struct used by BPF_PROG_QUERY command */
 		__u32		target_fd;	/* container object to query */

--- a/include/uapi/linux/if_link.h
+++ b/include/uapi/linux/if_link.h
@@ -1182,11 +1182,13 @@ enum {
 #define XDP_FLAGS_DRV_MODE		(1U << 2)
 #define XDP_FLAGS_HW_MODE		(1U << 3)
 #define XDP_FLAGS_REPLACE		(1U << 4)
+#define XDP_FLAGS_USE_METADATA		(1U << 5)
 #define XDP_FLAGS_MODES			(XDP_FLAGS_SKB_MODE | \
 					 XDP_FLAGS_DRV_MODE | \
 					 XDP_FLAGS_HW_MODE)
 #define XDP_FLAGS_MASK			(XDP_FLAGS_UPDATE_IF_NOEXIST | \
-					 XDP_FLAGS_MODES | XDP_FLAGS_REPLACE)
+					 XDP_FLAGS_MODES | XDP_FLAGS_REPLACE | \
+					 XDP_FLAGS_USE_METADATA)
 
 /* These are stored into IFLA_XDP_ATTACHED on dump. */
 enum {

--- a/kernel/bpf/cpumap.c
+++ b/kernel/bpf/cpumap.c
@@ -215,6 +215,7 @@ static int cpu_map_bpf_prog_run_xdp(struct bpf_cpu_map_entry *rcpu,
 {
 	struct xdp_rxq_info rxq;
 	struct xdp_buff xdp;
+	volatile struct xdp_meta_generic xdp_meta_generic;
 	int i, nframes = 0;
 
 	xdp_set_return_frame_no_direct();

--- a/kernel/bpf/syscall.c
+++ b/kernel/bpf/syscall.c
@@ -4542,6 +4542,25 @@ out_prog_put:
 	return ret;
 }
 
+#define BPF_BTF_VMLINUX_INFO_LAST_FIELD info.info
+
+static int bpf_btf_get_vmlinux_info(const union bpf_attr *attr,
+				    union bpf_attr __user *uattr)
+{
+	struct bpf_btf_info __user *uinfo = u64_to_user_ptr(attr->info.info);
+	u32 info_len = attr->info.info_len;
+	int err;
+
+	if (CHECK_ATTR(BPF_BTF_VMLINUX_INFO))
+		return -EINVAL;
+	
+	err = bpf_check_uarg_tail_zero(USER_BPFPTR(uinfo), sizeof(*uinfo), info_len);
+	if (err)
+		return err;
+
+	return btf_get_info_by_fd(bpf_get_btf_vmlinux(), attr, uattr);
+}
+
 static int __sys_bpf(int cmd, bpfptr_t uattr, unsigned int size)
 {
 	union bpf_attr attr;
@@ -4677,6 +4696,9 @@ static int __sys_bpf(int cmd, bpfptr_t uattr, unsigned int size)
 		break;
 	case BPF_PROG_BIND_MAP:
 		err = bpf_prog_bind_map(&attr);
+		break;
+	case BPF_BTF_VMLINUX_INFO:
+		err = bpf_btf_get_vmlinux_info(&attr, uattr.user);
 		break;
 	default:
 		err = -EINVAL;

--- a/samples/bpf/Makefile
+++ b/samples/bpf/Makefile
@@ -57,6 +57,7 @@ tprogs-y += xdp_redirect_map_multi
 tprogs-y += xdp_redirect_map
 tprogs-y += xdp_redirect
 tprogs-y += xdp_monitor
+tprogs-y += xdp_meta
 
 # Libbpf dependencies
 LIBBPF = $(TOOLS_PATH)/lib/bpf/libbpf.a
@@ -118,6 +119,7 @@ xdp_redirect_cpu-objs := xdp_redirect_cpu_user.o $(XDP_SAMPLE)
 xdp_redirect_map-objs := xdp_redirect_map_user.o $(XDP_SAMPLE)
 xdp_redirect-objs := xdp_redirect_user.o $(XDP_SAMPLE)
 xdp_monitor-objs := xdp_monitor_user.o $(XDP_SAMPLE)
+xdp_meta-objs := xdp_meta_user.o
 
 # Tell kbuild to always build the programs
 always-y := $(tprogs-y)
@@ -314,6 +316,7 @@ $(obj)/xdp_redirect_map_multi_user.o: $(obj)/xdp_redirect_map_multi.skel.h
 $(obj)/xdp_redirect_map_user.o: $(obj)/xdp_redirect_map.skel.h
 $(obj)/xdp_redirect_user.o: $(obj)/xdp_redirect.skel.h
 $(obj)/xdp_monitor_user.o: $(obj)/xdp_monitor.skel.h
+$(obj)/xdp_meta_user.o: $(obj)/xdp_meta.skel.h
 
 $(obj)/tracex5_kern.o: $(obj)/syscall_nrs.h
 $(obj)/hbm_out_kern.o: $(src)/hbm.h $(src)/hbm_kern.h
@@ -371,7 +374,8 @@ $(obj)/%.bpf.o: $(src)/%.bpf.c $(obj)/vmlinux.h $(src)/xdp_sample.bpf.h $(src)/x
 		-c $(filter %.bpf.c,$^) -o $@
 
 LINKED_SKELS := xdp_redirect_cpu.skel.h xdp_redirect_map_multi.skel.h \
-		xdp_redirect_map.skel.h xdp_redirect.skel.h xdp_monitor.skel.h
+		xdp_redirect_map.skel.h xdp_redirect.skel.h xdp_monitor.skel.h \
+		xdp_meta.skel.h
 clean-files += $(LINKED_SKELS)
 
 xdp_redirect_cpu.skel.h-deps := xdp_redirect_cpu.bpf.o xdp_sample.bpf.o
@@ -379,9 +383,9 @@ xdp_redirect_map_multi.skel.h-deps := xdp_redirect_map_multi.bpf.o xdp_sample.bp
 xdp_redirect_map.skel.h-deps := xdp_redirect_map.bpf.o xdp_sample.bpf.o
 xdp_redirect.skel.h-deps := xdp_redirect.bpf.o xdp_sample.bpf.o
 xdp_monitor.skel.h-deps := xdp_monitor.bpf.o xdp_sample.bpf.o
+xdp_meta.skel.h-deps := xdp_meta.bpf.o
 
 LINKED_BPF_SRCS := $(patsubst %.bpf.o,%.bpf.c,$(foreach skel,$(LINKED_SKELS),$($(skel)-deps)))
-
 BPF_SRCS_LINKED := $(notdir $(wildcard $(src)/*.bpf.c))
 BPF_OBJS_LINKED := $(patsubst %.bpf.c,$(obj)/%.bpf.o, $(BPF_SRCS_LINKED))
 BPF_SKELS_LINKED := $(addprefix $(obj)/,$(LINKED_SKELS))

--- a/samples/bpf/xdp_meta.bpf.c
+++ b/samples/bpf/xdp_meta.bpf.c
@@ -1,0 +1,55 @@
+/* This program is free software; you can redistribute it and/or
+ * modify it under the terms of version 2 of the GNU General Public
+ * License as published by the Free Software Foundation.
+ */
+#include "vmlinux.h"
+
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+
+struct xdp_meta_generic___minimal {
+	u32 btf_id;
+	u16 rxcvid;
+	u32 hash;
+};
+
+SEC("xdp")
+int xdp_meta_prog(struct xdp_md *ctx)
+{
+	struct xdp_meta_generic___minimal *data_meta =
+		(void *)(long)ctx->data_meta;
+	void *data_end = (void *)(long)ctx->data_end;
+	void *data = (void *)(long)ctx->data;
+	struct ethhdr *eth = data;
+	u64 nh_off;
+	u32 btf_id_libbpf;
+	u32 btf_id_meta;
+	s32 err;
+	long *value;
+
+	nh_off = sizeof(*eth);
+	if (data + nh_off > data_end)
+		return XDP_DROP;
+
+	
+	if (data_meta + 1 > data)
+		return XDP_DROP;
+
+	btf_id_libbpf = bpf_core_type_id_kernel(struct xdp_meta_generic___minimal);
+	err = bpf_probe_read_kernel(&btf_id_meta, sizeof(btf_id_meta), (void*)data - 4);
+
+	/* Probably should not be in the final version */
+	if (err){
+		bpf_printk("id from libbpf %d, could not obtain id from hints metadata, error is %d\n",
+			   btf_id_libbpf, err);
+		return XDP_DROP;
+	}
+
+	bpf_printk("id from libbpf %d, id from hints metadata %d\n",
+		   btf_id_libbpf, btf_id_meta);
+
+	return XDP_PASS;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/samples/bpf/xdp_meta_user.c
+++ b/samples/bpf/xdp_meta_user.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <ctype.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <sys/resource.h>
 #include <net/if.h>
@@ -14,12 +15,45 @@
 #include <linux/if_link.h>
 #include "xdp_meta.skel.h"
 
+#define DEBUGFS "/sys/kernel/debug/tracing/"
+
+static volatile bool xdp_meta_sample_running = true;
+
+static void xdp_meta_sample_stop(int signo)
+{
+	xdp_meta_sample_running = false;
+}
+
+/* Had to change the standard read_trace_pipe from trace_helpers.h */
+static void xdp_meta_read_trace_pipe(void)
+{
+	int trace_fd;
+
+	trace_fd = open(DEBUGFS "trace_pipe", O_RDONLY, 0);
+	if (trace_fd < 0){
+		fprintf(stderr, "Could not open the trace_pipe\n");
+		return;
+	}
+
+	while (xdp_meta_sample_running) {
+		static char buf[4096];
+		ssize_t sz;
+
+		sz = read(trace_fd, buf, sizeof(buf) - 1);
+		if (sz > 0) {
+			buf[sz] = 0;
+			puts(buf);
+		}
+	}
+}
+
 int main(int argc, char **argv)
 {
 	__u32 xdp_flags = XDP_FLAGS_UPDATE_IF_NOEXIST | XDP_FLAGS_USE_METADATA;
-	__u32 prog_id, prog_fd;
+	__u32 prog_id, prog_fd, running_prog_id;
 	struct xdp_meta *skel;
 	int ifindex, ret = 1;
+	struct sigaction handle_ctrl_c;
 
 	if (argc == optind) {
 		return ret;
@@ -51,20 +85,32 @@ int main(int argc, char **argv)
 	ret = 1;
 	prog_fd = bpf_program__fd(skel->progs.xdp_meta_prog);
 	if (bpf_set_link_xdp_fd(ifindex, prog_fd, xdp_flags) < 0) {
-		fprintf(stderr, "Failed to set xdp link");
+		fprintf(stderr, "Failed to set xdp link\n");
 		goto end_destroy;
 	}
 
 	if (bpf_get_link_xdp_id(ifindex, &prog_id, xdp_flags)) {
-		fprintf(stderr, "Failed to get XDP program id for ifindex");
+		fprintf(stderr, "Failed to get XDP program id for ifindex\n");
 		goto end_destroy;
 	}
 
-	while (1) {
-		sleep(2);
-	}
+	memset(&handle_ctrl_c, 0, sizeof(handle_ctrl_c));
+	handle_ctrl_c.sa_handler = &xdp_meta_sample_stop;
+	sigaction(SIGINT, &handle_ctrl_c, NULL);
+
+	xdp_meta_read_trace_pipe();
 
 	ret = 0;
+
+	if(bpf_get_link_xdp_id(ifindex, &running_prog_id, xdp_flags) || running_prog_id != prog_id){
+		fprintf(stderr,
+			"Failed to get the running XDP program id or another program is running. Exit without detaching.\n");
+		goto end_destroy;
+	}
+
+	fprintf(stderr, "Detaching the program...\n");
+	bpf_set_link_xdp_fd(ifindex, -1, 0);
+
 end_destroy:
 	xdp_meta__destroy(skel);
 end:

--- a/samples/bpf/xdp_meta_user.c
+++ b/samples/bpf/xdp_meta_user.c
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <ctype.h>
+#include <unistd.h>
+#include <sys/resource.h>
+#include <net/if.h>
+#include <time.h>
+#include <signal.h>
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+#include <linux/if_link.h>
+#include "xdp_meta.skel.h"
+
+int main(int argc, char **argv)
+{
+	__u32 xdp_flags = XDP_FLAGS_UPDATE_IF_NOEXIST | XDP_FLAGS_USE_METADATA;
+	__u32 prog_id, prog_fd;
+	struct xdp_meta *skel;
+	int ifindex, ret = 1;
+
+	if (argc == optind) {
+		return ret;
+	}
+
+	ifindex = if_nametoindex(argv[optind]);
+	if (!ifindex)
+		ifindex = strtoul(argv[optind], NULL, 0);
+	if (!ifindex) {
+		fprintf(stderr, "Bad interface index or name\n");
+		goto end;
+	}
+
+	skel = xdp_meta__open();
+	if (!skel) {
+		fprintf(stderr, "Failed to xdp_meta__open: %s\n",
+			strerror(errno));
+		ret = 1;
+		goto end;
+	}
+
+	ret = xdp_meta__load(skel);
+	if (ret < 0) {
+		fprintf(stderr, "Failed to xdp_meta__load: %s\n", strerror(errno));
+		ret = 1;
+		goto end_destroy;
+	}
+
+	ret = 1;
+	prog_fd = bpf_program__fd(skel->progs.xdp_meta_prog);
+	if (bpf_set_link_xdp_fd(ifindex, prog_fd, xdp_flags) < 0) {
+		fprintf(stderr, "Failed to set xdp link");
+		goto end_destroy;
+	}
+
+	if (bpf_get_link_xdp_id(ifindex, &prog_id, xdp_flags)) {
+		fprintf(stderr, "Failed to get XDP program id for ifindex");
+		goto end_destroy;
+	}
+
+	while (1) {
+		sleep(2);
+	}
+
+	ret = 0;
+end_destroy:
+	xdp_meta__destroy(skel);
+end:
+	return ret;
+}

--- a/samples/bpf/xdp_redirect_map_multi.bpf.c
+++ b/samples/bpf/xdp_redirect_map_multi.bpf.c
@@ -5,11 +5,6 @@
 #include "xdp_sample.bpf.h"
 #include "xdp_sample_shared.h"
 
-enum {
-	BPF_F_BROADCAST		= (1ULL << 3),
-	BPF_F_EXCLUDE_INGRESS	= (1ULL << 4),
-};
-
 struct {
 	__uint(type, BPF_MAP_TYPE_DEVMAP_HASH);
 	__uint(key_size, sizeof(int));

--- a/tools/include/uapi/linux/bpf.h
+++ b/tools/include/uapi/linux/bpf.h
@@ -873,6 +873,7 @@ enum bpf_cmd {
 	BPF_ITER_CREATE,
 	BPF_LINK_DETACH,
 	BPF_PROG_BIND_MAP,
+	BPF_BTF_VMLINUX_INFO,
 };
 
 enum bpf_map_type {

--- a/tools/include/uapi/linux/if_link.h
+++ b/tools/include/uapi/linux/if_link.h
@@ -969,11 +969,13 @@ enum {
 #define XDP_FLAGS_DRV_MODE		(1U << 2)
 #define XDP_FLAGS_HW_MODE		(1U << 3)
 #define XDP_FLAGS_REPLACE		(1U << 4)
+#define XDP_FLAGS_USE_METADATA		(1U << 5)
 #define XDP_FLAGS_MODES			(XDP_FLAGS_SKB_MODE | \
 					 XDP_FLAGS_DRV_MODE | \
 					 XDP_FLAGS_HW_MODE)
 #define XDP_FLAGS_MASK			(XDP_FLAGS_UPDATE_IF_NOEXIST | \
-					 XDP_FLAGS_MODES | XDP_FLAGS_REPLACE)
+					 XDP_FLAGS_MODES | XDP_FLAGS_REPLACE | \
+					 XDP_FLAGS_USE_METADATA)
 
 /* These are stored into IFLA_XDP_ATTACHED on dump. */
 enum {

--- a/tools/lib/bpf/bpf.c
+++ b/tools/lib/bpf/bpf.c
@@ -1017,6 +1017,23 @@ retry:
 	return libbpf_err_errno(fd);
 }
 
+int bpf_get_vmlinux_btf_info(void *info, __u32 *info_len)
+{
+	union bpf_attr attr;
+	int err;
+
+	memset(&attr, 0, sizeof(attr));
+	attr.info.info_len = *info_len;
+	attr.info.info = ptr_to_u64(info);
+
+	err = sys_bpf(BPF_BTF_VMLINUX_INFO, &attr, sizeof(attr));
+
+	if (!err)
+		*info_len = attr.info.info_len;
+
+	return libbpf_err_errno(err);
+}
+
 int bpf_task_fd_query(int pid, int fd, __u32 flags, char *buf, __u32 *buf_len,
 		      __u32 *prog_id, __u32 *fd_type, __u64 *probe_offset,
 		      __u64 *probe_addr)

--- a/tools/lib/bpf/btf.c
+++ b/tools/lib/bpf/btf.c
@@ -430,6 +430,20 @@ const struct btf *btf__base_btf(const struct btf *btf)
 	return btf->base_btf;
 }
 
+__u32 btf__obj_id(const struct btf *btf)
+{
+	struct bpf_btf_info btf_info;
+	unsigned int len = sizeof(btf_info);
+	int err = 0;
+	int fd = btf__fd(btf);
+
+	memset(&btf_info, 0, sizeof(btf_info));
+	err = bpf_obj_get_info_by_fd(fd, &btf_info, &len);
+
+	if (err) return 0;
+	return btf_info.id;
+}
+
 /* internal helper returning non-const pointer to a type */
 struct btf_type *btf_type_by_id(struct btf *btf, __u32 type_id)
 {
@@ -1379,6 +1393,7 @@ struct btf *btf_get_from_fd(int btf_fd, struct btf *base_btf)
 
 exit_free:
 	free(ptr);
+	btf->fd = btf_fd;
 	return btf;
 }
 

--- a/tools/lib/bpf/btf.h
+++ b/tools/lib/bpf/btf.h
@@ -61,7 +61,6 @@ LIBBPF_API __s32 btf__find_by_name_kind(const struct btf *btf,
 					const char *type_name, __u32 kind);
 LIBBPF_API __u32 btf__get_nr_types(const struct btf *btf);
 LIBBPF_API const struct btf *btf__base_btf(const struct btf *btf);
-LIBBPF_API __u32 btf__obj_id(const struct btf *btf);
 LIBBPF_API const struct btf_type *btf__type_by_id(const struct btf *btf,
 						  __u32 id);
 LIBBPF_API size_t btf__pointer_size(const struct btf *btf);

--- a/tools/lib/bpf/btf.h
+++ b/tools/lib/bpf/btf.h
@@ -61,6 +61,7 @@ LIBBPF_API __s32 btf__find_by_name_kind(const struct btf *btf,
 					const char *type_name, __u32 kind);
 LIBBPF_API __u32 btf__get_nr_types(const struct btf *btf);
 LIBBPF_API const struct btf *btf__base_btf(const struct btf *btf);
+LIBBPF_API __u32 btf__obj_id(const struct btf *btf);
 LIBBPF_API const struct btf_type *btf__type_by_id(const struct btf *btf,
 						  __u32 id);
 LIBBPF_API size_t btf__pointer_size(const struct btf *btf);

--- a/tools/lib/bpf/libbpf.map
+++ b/tools/lib/bpf/libbpf.map
@@ -385,5 +385,4 @@ LIBBPF_0.5.0 {
 		btf__load_vmlinux_btf;
 		btf_dump__dump_type_data;
 		libbpf_set_strict_mode;
-		btf__obj_id;
 } LIBBPF_0.4.0;

--- a/tools/lib/bpf/libbpf.map
+++ b/tools/lib/bpf/libbpf.map
@@ -385,4 +385,5 @@ LIBBPF_0.5.0 {
 		btf__load_vmlinux_btf;
 		btf_dump__dump_type_data;
 		libbpf_set_strict_mode;
+		btf__obj_id;
 } LIBBPF_0.4.0;

--- a/tools/lib/bpf/libbpf_internal.h
+++ b/tools/lib/bpf/libbpf_internal.h
@@ -287,6 +287,8 @@ int bpf_object__variable_offset(const struct bpf_object *obj, const char *name,
 struct btf *btf_get_from_fd(int btf_fd, struct btf *base_btf);
 void btf_get_kernel_prefix_kind(enum bpf_attach_type attach_type,
 				const char **prefix, int *kind);
+__u32 btf_obj_id(const struct btf *btf);
+int bpf_get_vmlinux_btf_info(void *info, __u32 *info_len);
 
 struct btf_ext_info {
 	/*

--- a/tools/lib/bpf/relo_core.c
+++ b/tools/lib/bpf/relo_core.c
@@ -840,7 +840,7 @@ static int bpf_core_calc_relo(const char *prog_name,
 		err = bpf_core_calc_type_relo(relo, local_spec, &res->orig_val);
 		err = err ?: bpf_core_calc_type_relo(relo, targ_spec, &res->new_val);
 		if (!err && relo->kind == BPF_TYPE_ID_TARGET)
-			res->btf_obj_id = btf__obj_id(targ_spec->btf);
+			res->btf_obj_id = btf_obj_id(targ_spec->btf);
 	} else if (core_relo_is_enumval_based(relo->kind)) {
 		err = bpf_core_calc_enumval_relo(relo, local_spec, &res->orig_val);
 		err = err ?: bpf_core_calc_enumval_relo(relo, targ_spec, &res->new_val);

--- a/tools/lib/bpf/relo_core.c
+++ b/tools/lib/bpf/relo_core.c
@@ -763,6 +763,7 @@ struct bpf_core_relo_res
 	__u32 orig_type_id;
 	__u32 new_sz;
 	__u32 new_type_id;
+	__u32 btf_obj_id;
 };
 
 /* Calculate original and target relocation values, given local and target
@@ -787,6 +788,7 @@ static int bpf_core_calc_relo(const char *prog_name,
 	res->fail_memsz_adjust = false;
 	res->orig_sz = res->new_sz = 0;
 	res->orig_type_id = res->new_type_id = 0;
+	res->btf_obj_id = 0;
 
 	if (core_relo_is_field_based(relo->kind)) {
 		err = bpf_core_calc_field_relo(prog_name, relo, local_spec,
@@ -837,6 +839,8 @@ static int bpf_core_calc_relo(const char *prog_name,
 	} else if (core_relo_is_type_based(relo->kind)) {
 		err = bpf_core_calc_type_relo(relo, local_spec, &res->orig_val);
 		err = err ?: bpf_core_calc_type_relo(relo, targ_spec, &res->new_val);
+		if (!err && relo->kind == BPF_TYPE_ID_TARGET)
+			res->btf_obj_id = btf__obj_id(targ_spec->btf);
 	} else if (core_relo_is_enumval_based(relo->kind)) {
 		err = bpf_core_calc_enumval_relo(relo, local_spec, &res->orig_val);
 		err = err ?: bpf_core_calc_enumval_relo(relo, targ_spec, &res->new_val);
@@ -1025,7 +1029,8 @@ poison:
 		}
 
 		insn[0].imm = new_val;
-		insn[1].imm = 0; /* currently only 32-bit values are supported */
+		insn[1].imm = relo->kind == BPF_TYPE_ID_TARGET ?
+					    res->btf_obj_id : 0;
 		pr_debug("prog '%s': relo #%d: patched insn #%d (LDIMM64) imm64 %llu -> %u\n",
 			 prog_name, relo_idx, insn_idx,
 			 (unsigned long long)imm, new_val);


### PR DESCRIPTION
Now both module and vmlinux BTFs are loaded to libbpf directly
from kernel. I've decided to leave the old vmlinux loading process just
in case the new one fails.

Will push another option tomorrow.

Can't say I am fully satisfied with how this looks, so pls comment :)